### PR TITLE
Use "default" identifier to represent default quotas and rate limits.

### DIFF
--- a/versions/1.0.0-Draft.md
+++ b/versions/1.0.0-Draft.md
@@ -10,7 +10,7 @@ API Management tools can import and measure such key metrics and composed SLAs f
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
 in this document are to be interpreted as described in [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt).
 
-This specification is an on-going work developed by the [SLA4OAI Technical Committee](https://github.com/isa-group/SLA4OAI-TC) over the course of the last years. In the working discussions a number of practitioners and academics have participated, including: **Dave O'Neil** (Apimetrics), **Paul Cray** (Apimetrics), **Hyungjun Lim** (Google), **Khushan Adatiya** (Google), **Fran Mendez** (AsyncAPI), **Emmanuel Paraskakis** (Smartbear/Independent), **Phil Sturgeon** (Stoplight), **Nikhil Kolekar** (Paypal/Independent), **Prithpal Bhogill** (Google), **Madhurranjan Mohaan** (Google), **Isaac Hepworth** (ex-Google), **Scott Ganyo** (Google), **Kin Lane** (API Evangelist), **Mike Ralphson** (Independent), **Jeffrey ErnstFriedman** (OpenTravel Alliance), **Antonio Ruiz-Cortes** (ISA Group/University of Sevilla), **Pedro J. Molina** (Metadev/ISA Group) and **Pablo Fernandez** (ISA Group/University of Sevilla).
+This specification is an on-going work developed by the [SLA4OAI Technical Committee](https://github.com/isa-group/SLA4OAI-TC) over the course of the last years. In the working discussions a number of practitioners and academics have participated, including: **Dave O'Neil** (Apimetrics), **Paul Cray** (Apimetrics), **Hyungjun Lim** (Google), **Khushan Adatiya** (Google), **Fran Mendez** (AsyncAPI), **Emmanuel Paraskakis** (Smartbear/Independent), **Phil Sturgeon** (Stoplight), **Nikhil Kolekar** (Paypal/Independent), **Prithpal Bhogill** (Google), **Madhurranjan Mohaan** (Google), **Isaac Hepworth** (ex-Google), **Scott Ganyo** (Google), **Tim Burks** (Google), **Kin Lane** (API Evangelist), **Mike Ralphson** (Independent), **Jeffrey ErnstFriedman** (OpenTravel Alliance), **Antonio Ruiz-Cortes** (ISA Group/University of Sevilla), **Pedro J. Molina** (Metadev/ISA Group) and **Pablo Fernandez** (ISA Group/University of Sevilla).
 
 
 
@@ -255,6 +255,9 @@ quotas:
           period: hourly
 ```
 
+Path names can include the special path name "default", which can be used to specify quotas for all paths
+that aren't otherwise specified.
+
 #### 3.1.3 Rates Object
 Rates are limits computed in **dynamic** time windows relatives to the usage of the service; as an example, a *minutely rate* refers to the period of 60 seconds immediately before the last operation of each API consumer. 
  
@@ -275,6 +278,9 @@ rates:
         - max: 5
           period: secondly
 ```
+
+Path names can include the special path name "default", which can be used to specify rate limits for all paths
+that aren't otherwise specified.
 
 #### 3.1.4 Path Object
 The API endpoint path.

--- a/versions/1.0.0-Draft.md
+++ b/versions/1.0.0-Draft.md
@@ -255,8 +255,7 @@ quotas:
           period: hourly
 ```
 
-Path names can include the special path name "default", which can be used to specify quotas for all paths
-that aren't otherwise specified.
+Path names can include the special path name "default", which can be used to specify quotas for all paths that aren't otherwise specified.
 
 #### 3.1.3 Rates Object
 Rates are limits computed in **dynamic** time windows relatives to the usage of the service; as an example, a *minutely rate* refers to the period of 60 seconds immediately before the last operation of each API consumer. 
@@ -279,8 +278,7 @@ rates:
           period: secondly
 ```
 
-Path names can include the special path name "default", which can be used to specify rate limits for all paths
-that aren't otherwise specified.
+Path names can include the special path name "default", which can be used to specify rate limits for all paths that aren't otherwise specified.
 
 #### 3.1.4 Path Object
 The API endpoint path.


### PR DESCRIPTION
This addresses #7 with a simpler suggestion than what was most recently discussed in the thread. In that discussion, we favored using glob patterns (using "\*" as a wildcard) to match groups of paths.

While they are widely used, I did not find standard definitions for glob patterns that seemed suitable for citing from a standards document. One person that I discussed this with suggested using the [robots.txt](https://tools.ietf.org/html/draft-rep-wg-topic-00#section-2.2.3) specification, which defines the "\*" special character as "matching 0 or more instances of any character" (presumably excluding "/"). The exclusion of "/" makes this inappropriate for our usage, as we would want a way to specify all paths with a single expression. We might consider redefining "\*" or using a different wildcard (e.g. "\*\*") but I feel that it would not be good to use a close-but-different meaning or to define our own wildcards for this relatively-small specification extension.

Ideally a method for specifying groups of paths would be part of the broader OpenAPI Specification. 

In [proposals/004_Overlays.md](https://github.com/OAI/OpenAPI-Specification/blob/master/proposals/004_Overlays.md), Darrel Miller proposes a mechanism for applying JSON (or YAML) fragments to an OpenAPI document at targets specified with [JMESPath](https://jmespath.org/) expressions. If approved, this might allow quotas and rates to be applied to groups of operations using overlays. However, it assumes that quotas and rates for individual paths could be attached directly to path objects in an OpenAPI description, and this does not seem to be possible with the current structure of the SLA4OAI Specification, which places paths in `rates` and `quotas` objects. 

This seems worth discussing with the OpenAPI technical committee. The most recent overlays proposal is a year old and might still be revised before being accepted into the standard, and the committee may have suggestions for ways to restructure the SLA4OAI spec to be more compatible with overlays.

"default" is proposed here because it seems to be the simplest way to provide for default values while avoiding the complexity of nonstandard definitions of wildcards and the difficulties (noted above) of using overlays with the SLA4OAI spec. 