### PR TITLE
Removing space from `Open API` in title

### DIFF
--- a/versions/1.0.0-Draft.md
+++ b/versions/1.0.0-Draft.md
@@ -1,4 +1,4 @@
-# SLA for the Open API Initiative Specification
+# SLA for the OpenAPI Initiative Specification
 
 **SLA4OAI** is an open source standard for describing SLA in APIs.
 


### PR DESCRIPTION
This will align it with branding guidelines for the spec.