### PR TITLE
Added 'type' to schema's Limit Object

### DIFF
--- a/schemas/1.0.0-Draft.schema.json
+++ b/schemas/1.0.0-Draft.schema.json
@@ -229,6 +229,13 @@
                   "$ref": "#/definitions/Period",
                   "description": "The period of the limit.",
                   "title": "period"
+              },
+              "type": {
+                "description": "Specifies how the API handles requests to the given endpoint, can be one of 'burst' or 'average'. The default value is 'burst'",
+                "enum": ["burst","average"],
+                "title": "type",
+                "type": "string",
+                "default": "burst"
               }
           },
           "required": ["max"],

--- a/versions/Working-Draft.md
+++ b/versions/Working-Draft.md
@@ -376,11 +376,18 @@ The allowed limits of the metric (e.g. *requests*).
 | :------------- | :--------- | :------------|
 | max            | `number`   |  **Required** Maximum value that can be reached so the limit is not violated. |
 | period         | `string`   |  **Optional** The period specified for the given limit; it should be one of the following possible values: `second`, `minute`, `hour`, `day`, `month` or `year`. In case it is not specified, it would be a **permanent** limit over the metric. |
+| type           | `string`   |  **Optional** Specifies how the API handles requests to the given endpoint, can be one of `burst` or `average` (for further explanation see below). The default value is `burst`. |
+
+The difference between `burst` and `average` is better explained with an example. Supposing an endpoint that allows 10 requests per minute:
+
+- `average`: Would allow an average of 10 requests per minute, meaning only one request every 6 seconds would be accepted. Any other request received within these 6-second intervals would be rejected with HTTP code 429. 
+- `burst`: Would allow all 10 requests to be served at the any time during the minute. Once 10 requests have been served and until the end of the minute, all successive requests would be rejected with HTTP code 429.
 
 **Example:**
 ```yaml
 max: 2
 period: second
+type: burst
 ```
 
 ## References

--- a/versions/samples/petstore/petstore-plans.yml
+++ b/versions/samples/petstore/petstore-plans.yml
@@ -18,6 +18,7 @@ plans:
           requests:
             - max: 1
               period: second
+              type: average
   pro:
     pricing:
       cost: 5
@@ -29,15 +30,11 @@ plans:
           requests:
             - max: 20
               period: minute
-              scope: account
             - max: 100
               period: hour
-              scope: tenant
+              type: average
         post:
           requests:
             - max: 100
               period: minute
-          resourceInstances:
-            - max: 500
-          animalTypes:
-            - max: 5
+              type: burst

--- a/versions/samples/petstore/pro-petstore-sla.yml
+++ b/versions/samples/petstore/pro-petstore-sla.yml
@@ -22,21 +22,18 @@ plan:
         requests:
           - max: 20
             period: minute
-            scope: account
+            type: burst
           - max: 100
             period: hour
-            scope: tenant
+            type: average
       post:
         requests:
           - max: 100
             period: minute
-        resourceInstances:
-          - max: 500
-        animalTypes:
-          - max: 5
   rates:
     /pets/{id}:
       get:
         requests:
           - max: 3
             period: second
+            type: average


### PR DESCRIPTION
Often, proxies can be configured in two ways for handling requests and applying rate limiting: average and burst. For example, if an endpoint allows 10 requests per minute:

- **Average**: Would allow an average of 10 requests per minute, meaning only one request every 6 seconds would be accepted. Any other request received within these 6-second intervals would be rejected with HTTP code 429. 
- **Burst**: Would allow all 10 requests to be served at the any time during the minute. Once 10 requests have been served and until the end of the minute, all successive requests would be rejected with HTTP code 429.

With this PR I have modified the schema to allow specifying on the SLA how the API handles requests targeting a given endpoint: Limit Object's `type` can be set to `burst` or `average`. 

(cc @pafmon)